### PR TITLE
week4: remove redownloading and reextraction

### DIFF
--- a/week04_finetuning/seminar_pytorch.ipynb
+++ b/week04_finetuning/seminar_pytorch.ipynb
@@ -182,8 +182,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://www.dropbox.com/s/ae1lq6dsfanse76/dogs_vs_cats.train.zip?dl=1 -O data.zip\n",
-    "!unzip data.zip"
+    "!wget -nc https://www.dropbox.com/s/ae1lq6dsfanse76/dogs_vs_cats.train.zip?dl=1 -O data.zip\n",
+    "!unzip -n data.zip"
    ]
   },
   {


### PR DESCRIPTION
unzip without flags asks user to resolve conflict of existing files, that are not good for Notebooks
-n do not overwrite
-o overwrite