### PR TITLE
week4: removed old scipy func -> up-to-date approach

### DIFF
--- a/week04_finetuning/seminar_pytorch.ipynb
+++ b/week04_finetuning/seminar_pytorch.ipynb
@@ -235,7 +235,8 @@
    "source": [
     "#extract features from images\n",
     "from tqdm import tqdm\n",
-    "from scipy.misc import imread, imresize\n",
+    "from image.io import imread\n",
+    "import PIL.Image as Image\n",
     "import os\n",
     "\n",
     "X = []\n",
@@ -252,7 +253,7 @@
     "    \n",
     "    img = imread(os.path.join(\"train\", fname))\n",
     "    \n",
-    "    img = imresize(img, (299, 299)) / 255.\n",
+    "    img = np.array(Image.fromarray(img).resize((299, 299))) / 255.\n",
     "    imgs[batch_index] = img\n",
     "    \n",
     "    if batch_index == batch_size - 1:\n",


### PR DESCRIPTION
https://docs.scipy.org/doc/scipy-1.2.0/reference/generated/scipy.misc.imread.html :
imread is deprecated! imread is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use imageio.imread instead.

https://docs.scipy.org/doc/scipy-1.2.0/reference/generated/scipy.misc.imresize.html :
imresize is deprecated! imresize is deprecated in SciPy 1.0.0, and will be removed in 1.3.0. Use Pillow instead: numpy.array(Image.fromarray(arr).resize()).