### PR TITLE
resolve few typos

### DIFF
--- a/homework03/homework03_part2_vae_advanced.ipynb
+++ b/homework03/homework03_part2_vae_advanced.ipynb
@@ -374,9 +374,9 @@
     "    \n",
     "    def gaussian_sampler(self, mu, logsigma):\n",
     "        if self.training:\n",
-    "            std = logsigma.exp_()\n",
+    "            std = logsigma.exp()\n",
     "            eps = Variable(std.data.new(std.size()).normal_())\n",
-    "            return eps.mul(std).add_(mu)\n",
+    "            return eps.mul(std).add(mu)\n",
     "        else:\n",
     "            return mu\n",
     "\n",
@@ -392,12 +392,12 @@
    "source": [
     "And the last, but not least! Place in the code where the most of the formulaes goes to - optimization objective. The objective for VAE has it's own name - variational lowerbound. And as for any lowerbound our intention is to maximize it. Here it is (for one sample $z$ per input $x$):\n",
     "\n",
-    "$$\\mathcal{L} = -D_{KL}(q_{\\phi}(z|x)||p_{\\theta}(z)) + \\log p_{\\theta}(x|z)$$\n",
+    "$$\\mathcal{L} = -D_{KL}(q_{\\phi}(z|x)||p(z)) + \\log p_{\\theta}(x|z)$$\n",
     "\n",
     "Your next task is to implement two functions that compute KL-divergence and the second term - log-likelihood of an output. Here is some necessary math for your convenience:\n",
     "\n",
     "$$D_{KL} = -\\frac{1}{2}\\sum_{i=1}^{dimZ}(1+log(\\sigma_i^2)-\\mu_i^2-\\sigma_i^2)$$\n",
-    "$$\\log p_{\\theta}(x|z) = \\sum_{i=1}^{dimX}\\log p_{\\theta}(x_i|z)=\\sum_{i=1}^{dimX} \\log \\Big( \\frac{1}{\\sigma_i\\sqrt{2\\pi}}e^{-\\frac{(\\mu_I-x)^2}{2\\sigma_i^2}} \\Big)=...$$\n",
+    "$$\\log p_{\\theta}(x|z) = \\sum_{i=1}^{dimX}\\log p_{\\theta}(x_i|z)=\\sum_{i=1}^{dimX} \\log \\Big( \\frac{1}{\\sigma_i\\sqrt{2\\pi}}e^{-\\frac{(\\mu_i-x)^2}{2\\sigma_i^2}} \\Big)=...$$\n",
     "\n",
     "Don't forget in the code that you are using $\\log\\sigma$ as variable. Explain, why not $\\sigma$?"
    ]
@@ -555,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Pytorch throws an exception when processing a backward pass from a variable that was obtained from the gaussian_sampler function, because exp_ and add_ are inplace functions. (pytorch version 1.4.0)

Two typos in math, first -- we need to compute KL divergence between posterior and prior distributions, second -- just upper case typo.