### PR TITLE
Error in the `Word2Vec` model's parameters.

### DIFF
--- a/week05_nlp/seminar.ipynb
+++ b/week05_nlp/seminar.ipynb
@@ -118,9 +118,9 @@
    "source": [
     "from gensim.models import Word2Vec\n",
     "model = Word2Vec(data_tok, \n",
-    "                 size=32,      # embedding vector size\n",
-    "                 min_count=5,  # consider words that occured at least 5 times\n",
-    "                 window=5).wv  # define context as a 5-word window around the target word"
+    "                 vector_size=32,      # embedding vector size\n",
+    "                 min_count=5,         # consider words that occured at least 5 times\n",
+    "                 window=5).wv         # define context as a 5-word window around the target word"
    ]
   },
   {


### PR DESCRIPTION
Gensim Word2Vec doesn't have `size` as a parameter. Instead, it has `vector_size` for the embedding vector size.