### PR TITLE
`KeyedVector` removed in Gensim 4.0.0.

### DIFF
--- a/week05_nlp/seminar.ipynb
+++ b/week05_nlp/seminar.ipynb
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "words = sorted(model.vocab.keys(), \n",
-    "               key=lambda word: model.vocab[word].count,\n",
+    "               key=lambda word: model.key_to_index[word],\n",
     "               reverse=True)[:1000]\n",
     "\n",
     "print(words[::100])"


### PR DESCRIPTION
AttributeError: The vocab attribute was removed from KeyedVector in Gensim 4.0.0.

> Use KeyedVector's .key_to_index dict, .index_to_key list, and methods .get_vecattr(key, attr) and .set_vecattr(key, attr, new_val) instead.