### PR TITLE
Fixing the issue regards Google Colab Visualization

### DIFF
--- a/week07_interpretability/practice.ipynb
+++ b/week07_interpretability/practice.ipynb
@@ -344,6 +344,7 @@
     "shap_values = explainer.shap_values(X)\n",
     "\n",
     "# visualize explanation of the first example\n",
+    "shap.initjs() #For re-run the Javascript initialization on Google Colab\n",
     "shap.force_plot(explainer.expected_value, shap_values[0, :], X.iloc[0, :])"
    ]
   },

--- a/week07_interpretability/practice.ipynb
+++ b/week07_interpretability/practice.ipynb
@@ -356,6 +356,7 @@
    "source": [
     "# Explain training data: each *column* is a rotated plot from above, stacked for all training samples\n",
     "# (this plot is interactive, hover mouse to see feature names)\n",
+    "shap.initjs() #For re-run the Javascript initialization on Google Colab\n",
     "shap.force_plot(explainer.expected_value, shap_values, X)"
    ]
   },


### PR DESCRIPTION
Fixing the issue regards Google Colab SHAP visualization. We can't visualize the `TreeExplainer` on google Colab without reinitializing the javascript again.